### PR TITLE
Remove shared library for vectorscan

### DIFF
--- a/build/arm64/Makefile
+++ b/build/arm64/Makefile
@@ -29,7 +29,6 @@ stage_enf_base: stage_fleet_base
 	gzip -cd prebuild/binary/consul_1.11.11_linux_arm64.gz > ${STAGE_DIR}/usr/local/bin/consul
 	chmod +x ${STAGE_DIR}/usr/local/bin/consul
 	cp prebuild/binary/libjemalloc.so.2 ${STAGE_DIR}/usr/local/bin/
-	cp prebuild/binary/libhs.so.5.4.9 ${STAGE_DIR}/usr/local/bin/libhs.so.5
 
 stage_mgr_base:
 	mkdir -p ${STAGE_DIR}/etc/neuvector/certs/


### PR DESCRIPTION
Remove shared lib for vectorscan form enforcer base image as we'll use static lib in build container