### PR TITLE
fix: NVSHAS-9210 not include built-in certs in manager

### DIFF
--- a/build/amd64/Makefile
+++ b/build/amd64/Makefile
@@ -46,9 +46,6 @@ stage_enf_base: stage_fleet_base
 	cp prebuild/binary/libmnl.so.0.1.0 ${STAGE_DIR}/usr/local/bin/libmnl.so.0.1.0
 
 stage_mgr_base:
-	mkdir -p ${STAGE_DIR}/etc/neuvector/certs/
-	cp ../share/etc/neuvector/certs/ssl-cert.pem ${STAGE_DIR}/etc/neuvector/certs/
-	cp ../share/etc/neuvector/certs/ssl-cert.key ${STAGE_DIR}/etc/neuvector/certs/
 	cp requirements.txt ${STAGE_DIR}/
 
 stage_adpt_base: stage_fleet_base

--- a/build/arm64/Makefile
+++ b/build/arm64/Makefile
@@ -35,9 +35,6 @@ stage_enf_base: stage_fleet_base
 	cp prebuild/binary/libpcre.so.3.13.3 ${STAGE_DIR}/usr/lib64/
 
 stage_mgr_base:
-	mkdir -p ${STAGE_DIR}/etc/neuvector/certs/
-	cp ../share/etc/neuvector/certs/ssl-cert.pem ${STAGE_DIR}/etc/neuvector/certs/
-	cp ../share/etc/neuvector/certs/ssl-cert.key ${STAGE_DIR}/etc/neuvector/certs/
 	cp requirements.txt ${STAGE_DIR}/
 
 stage_adpt_base: stage_fleet_base


### PR DESCRIPTION
Remove manager's built-in certs as this will be auto-generated moving forward.