### PR TITLE
Remove unused setuptools package

### DIFF
--- a/build/amd64/Dockerfile.all_base
+++ b/build/amd64/Dockerfile.all_base
@@ -6,6 +6,7 @@ COPY stage /
 RUN apk --update add ca-certificates ethtool lsof procps curl jq supervisor && \
     apk add --allow-untrusted --force-overwrite /glibc-2.33-r0.apk && apk update && apk upgrade && \
     rm -rf /tmp/* && rm -rf /var/cache/apk/* /glibc-2.33-r0.apk && \
+    rm -rf /usr/lib/python3.12/site-packages/setuptools* && \
     ln -s /usr/local/bin/libpcre.so.3.13.1 /usr/glibc-compat/lib/libpcre.so.3 && \
     ln -s /usr/local/bin/libstdc++.so.6.0.19 /usr/local/bin/libstdc++.so.6 && \
     ln -s /usr/local/bin/libnfnetlink.so.0.2.0 /usr/local/bin/libnfnetlink.so.0 && \


### PR DESCRIPTION
supervisor package will include the unused "setuptools" which has unresolved CVE.