### PR TITLE
NVSHAS-9356: uses the BCI 15.5 temporally on the ARM64's allinone and manager base images

### DIFF
--- a/build/arm64/Dockerfile.all_base
+++ b/build/arm64/Dockerfile.all_base
@@ -1,5 +1,5 @@
 FROM neuvector/manager_base AS micro
-FROM registry.suse.com/bci/bci-base:15.6 AS builder
+FROM registry.suse.com/bci/bci-base:15.5 AS builder
 
 COPY --from=micro / /chroot/
 RUN zypper --installroot /chroot -n --gpg-auto-import-keys in --no-recommends \

--- a/build/arm64/Dockerfile.manager_base
+++ b/build/arm64/Dockerfile.manager_base
@@ -1,5 +1,5 @@
-FROM registry.suse.com/bci/bci-micro:15.6 AS micro
-FROM registry.suse.com/bci/bci-base:15.6 AS builder
+FROM registry.suse.com/bci/bci-micro:15.5 AS micro
+FROM registry.suse.com/bci/bci-base:15.5 AS builder
 
 ENV JAVA_VERSION=11.0.21_p9-r0 \
     JAVA_HOME=/usr/lib/jvm/java-1.11-openjdk/jre \


### PR DESCRIPTION
Referring to NVSHAS-9354, some python packages are not compatible with the BCI 15.6. To remove the release block, it is necessary to reverse them to 15.5 temporally until it is fixed at the provider side.