### PR TITLE
NVSHAS-9354: Fix Arm64 BCI base image change

### DIFF
--- a/build/arm64/Dockerfile.all_base
+++ b/build/arm64/Dockerfile.all_base
@@ -1,17 +1,31 @@
-FROM neuvector/manager_base AS micro
-FROM registry.suse.com/bci/bci-base:15.5 AS builder
+FROM registry.suse.com/bci/bci-micro:15.6 AS micro
+FROM registry.suse.com/bci/bci-base:15.6 AS builder
+
+ENV JAVA_VERSION=11.0.24_p8-r0 \
+    JAVA_HOME=/usr/lib/jvm/java-1.11-openjdk/jre \
+    PATH=$PATH:/usr/lib/jvm/java-1.11-openjdk/jre/bin:/usr/lib/jvm/java-1.11-openjdk/bin \
+    LANG=C.UTF-8 \
+    PYTHONUNBUFFERED=1
 
 COPY --from=micro / /chroot/
 RUN zypper --installroot /chroot -n --gpg-auto-import-keys in --no-recommends \
-    libnetfilter_queue-devel liburcu-devel libpcap-devel pcre2-devel libjansson-devel libmnl-devel \
-    iproute2 ethtool lsof procps grep && \
+    python312 python312-pip java-11-openjdk \
+    iproute2 lsof procps grep ethtool awk \
+    libnetfilter_queue-devel liburcu-devel libpcap-devel pcre2-devel libjansson-devel libmnl-devel && \
     zypper --installroot /chroot clean -a && \
     rm -rf /chroot/var/log/
 
 FROM micro
 WORKDIR /
 COPY --from=builder /chroot/ /
+COPY --from=builder /usr/sbin/useradd /usr/sbin
 COPY stage /
 
+RUN ln -s /usr/bin/python3.12 /usr/bin/python && \
+    ln -s /usr/bin/python3.12 /usr/bin/python3  && \
+    pip3 install --upgrade setuptools && \
+    pip3 install --no-cache-dir -r /requirements.txt && \
+    rm -r /root/.cache /requirements.txt
+RUN cd /usr/bin/ && rm -rf basename chcon chgrp chmod chown chroot cksum dd df dircolors dirname du install install-info join locale localedef mkdir mkfifo mknod mktemp paste pathchk readlink realpath sync smidiff smidump smilink smiquery smistrip smixlate tee tiemout tload top truncate unlink watch
 RUN ln -s /usr/lib64/libpcap.so /usr/lib64/libpcap.so.0.8 && \
     ln -s /usr/lib64/libpcre.so.3.13.3 /usr/lib64/libpcre.so.3

--- a/build/arm64/Dockerfile.manager_base
+++ b/build/arm64/Dockerfile.manager_base
@@ -1,7 +1,7 @@
-FROM registry.suse.com/bci/bci-micro:15.5 AS micro
-FROM registry.suse.com/bci/bci-base:15.5 AS builder
+FROM registry.suse.com/bci/bci-micro:15.6 AS micro
+FROM registry.suse.com/bci/bci-base:15.6 AS builder
 
-ENV JAVA_VERSION=11.0.21_p9-r0 \
+ENV JAVA_VERSION=11.0.24_p8-r0 \
     JAVA_HOME=/usr/lib/jvm/java-1.11-openjdk/jre \
     PATH=$PATH:/usr/lib/jvm/java-1.11-openjdk/jre/bin:/usr/lib/jvm/java-1.11-openjdk/bin \
     LANG=C.UTF-8 \
@@ -9,8 +9,8 @@ ENV JAVA_VERSION=11.0.21_p9-r0 \
 
 COPY --from=micro / /chroot/
 RUN zypper --installroot /chroot -n --gpg-auto-import-keys in --no-recommends \
-    python311 python311-pip java-11-openjdk \
-   	iproute2 lsof procps grep awk && \
+    python312 python312-pip java-11-openjdk \
+    iproute2 lsof procps grep awk && \
     zypper --installroot /chroot clean -a && \
     rm -rf /chroot/var/log/
 
@@ -21,9 +21,9 @@ COPY --from=builder /chroot/ /
 COPY --from=builder /usr/sbin/useradd /usr/sbin
 COPY stage /
 
-RUN ln -s /usr/bin/python3.11 /usr/bin/python && \
-    ln -s /usr/bin/python3.11 /usr/bin/python3  && \
-    pip3 install --upgrade pip setuptools && \
+RUN ln -s /usr/bin/python3.12 /usr/bin/python && \
+    ln -s /usr/bin/python3.12 /usr/bin/python3  && \
+    pip3 install --upgrade setuptools && \
     pip3 install --no-cache-dir -r /requirements.txt && \
     rm -r /root/.cache /requirements.txt
 RUN cd /usr/bin/ && rm -rf basename chcon chgrp chmod chown chroot cksum dd df dircolors dirname du install install-info join locale localedef mkdir mkfifo mknod mktemp paste pathchk readlink realpath sync smidiff smidump smilink smiquery smistrip smixlate tee tiemout tload top truncate unlink watch

--- a/build/arm64/Makefile
+++ b/build/arm64/Makefile
@@ -63,7 +63,7 @@ manager_base: stage_init stage_mgr_base
 adapter_base: stage_init stage_adpt_base
 	docker build --no-cache=true -t neuvector/adapter_base -f Dockerfile.adapter_base .
 
-all_base: stage_init stage_enf_base stage_ctrl_base
+all_base: stage_init stage_enf_base stage_ctrl_base stage_mgr_base
 	docker build --no-cache=true -t neuvector/all_base -f Dockerfile.all_base .
 
 

--- a/build/arm64/requirements.txt
+++ b/build/arm64/requirements.txt
@@ -1,7 +1,7 @@
 click==8.1.2
 cmd2==2.3.3
 prettytable==2.5.0
-requests==2.31.0
+requests==2.32.0
 six==1.11.0
 supervisor==4.2.5
 urllib3==1.26.18


### PR DESCRIPTION
1. change base image for all_base and manager_base to BCI 15.6
2. change python311 to python312
3. remove pip3 upgrade