### PR TITLE
add grep (and ca-certificates) to arm64 updater image

### DIFF
--- a/build/arm64/Dockerfile.updater
+++ b/build/arm64/Dockerfile.updater
@@ -6,7 +6,7 @@ LABEL neuvector.image="neuvector/updater" \
 
 COPY --from=micro / /chroot/
 RUN zypper --installroot /chroot -n --gpg-auto-import-keys in --no-recommends \
-    curl && \
+    ca-certificates curl grep && \
     zypper --installroot /chroot clean -a && \
     rm -rf /chroot/var/log/
 


### PR DESCRIPTION
Add grep (and ca-certificates) to arm64 update image to fix neuvector/neuvector#1583 and make image to same as the AMD64 image.