### PR TITLE
fix: change /etc/neuvector/certs/internal to 660

### DIFF
--- a/build/amd64/Makefile
+++ b/build/amd64/Makefile
@@ -15,6 +15,7 @@ stage_fleet_base:
 	cp ../share/etc/neuvector/certs/internal/ca.cert ${STAGE_DIR}/etc/neuvector/certs/internal/
 	cp ../share/etc/neuvector/certs/internal/cert.key ${STAGE_DIR}/etc/neuvector/certs/internal/
 	cp ../share/etc/neuvector/certs/internal/cert.pem ${STAGE_DIR}/etc/neuvector/certs/internal/
+	chmod 660 ${STAGE_DIR}/etc/neuvector/certs/internal/*
 ifeq ("$(BASEOS)", "alpine")
 	cp prebuild/binary/glibc-2.33-r0.apk ${STAGE_DIR}/
 	cp ../share/etc/neuvector/certs/ssl-cert.pem ${STAGE_DIR}/etc/neuvector/certs/

--- a/build/arm64/Makefile
+++ b/build/arm64/Makefile
@@ -14,6 +14,7 @@ stage_fleet_base:
 	cp ../share/etc/neuvector/certs/internal/ca.cert ${STAGE_DIR}/etc/neuvector/certs/internal/
 	cp ../share/etc/neuvector/certs/internal/cert.key ${STAGE_DIR}/etc/neuvector/certs/internal/
 	cp ../share/etc/neuvector/certs/internal/cert.pem ${STAGE_DIR}/etc/neuvector/certs/internal/
+	chmod 660 ${STAGE_DIR}/etc/neuvector/certs/internal/*
 
 stage_scan_base: stage_fleet_base
 


### PR DESCRIPTION
Before this change, the permission of files under `/etc/neuvector/certs/internal` is 644, which would cause issues in OpenShift scenario when running with non-root user. 
![image](https://github.com/user-attachments/assets/87fde4f8-954c-472e-bbdf-12f7928d34eb)

This PR changes the permission to 664, so they are writable by root group in OpenShift scenario.