### PR TITLE
migration: upgrade verions for jdk(v11->v17), scala(v2.11.12->v3.3.4), sbt(v1.6.2->v1.10.2), and angular-cli(v13->v14) of dockerfiles.

### DIFF
--- a/build/amd64/Dockerfile.build_manager
+++ b/build/amd64/Dockerfile.build_manager
@@ -5,17 +5,17 @@ FROM ubuntu:22.04
 RUN apt-get update || true
 
 # Manager
-RUN apt-get install -y wget curl zip git default-jdk && \
+RUN apt-get install -y wget curl zip git openjdk-17-jdk && \
     apt-get install apt-transport-https
 
 RUN curl -fL https://github.com/coursier/launchers/raw/master/cs-x86_64-pc-linux.gz | gzip -d > cs && \
     chmod +x cs && \
     export PATH="$PATH:/root/.local/share/coursier/bin" && \
-    ./cs install scala:2.11.12 sbt:1.6.2 --install-dir /usr/local/bin
+    ./cs install scala:3.3.4 sbt:1.10.2 --install-dir /usr/local/bin
 
 RUN curl -fsSL https://deb.nodesource.com/setup_16.x | bash - && \
     apt-get install -uy nodejs && \
-    npm install -g @angular/cli@13 && \
+    npm install -g @angular/cli@14 && \
     npm install -g npm-force-resolutions
 
 # Manager unitest
@@ -23,7 +23,7 @@ RUN wget https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.d
     dpkg -i google-chrome-stable_current_amd64.deb; apt-get -fy install
 
 # Fix for sbt failure, an ubuntu issue
-RUN sed -i 's/pkcs12/jks/g' /etc/java-11-openjdk/security/java.security && \
+RUN sed -i 's/pkcs12/jks/g' /etc/java-17-openjdk/security/java.security && \
     dpkg --purge --force-depends ca-certificates-java && \
     apt-get install ca-certificates-java
 

--- a/build/amd64/alpine/Dockerfile.manager_base
+++ b/build/amd64/alpine/Dockerfile.manager_base
@@ -3,10 +3,10 @@ MAINTAINER support@neuvector.com
 
 COPY stage /
 
-ENV JAVA_VERSION=11.0.24_p8-r0 \
-    JAVA_ALPINE_VERSION=11.0.24_p8-r0 \
-    JAVA_HOME=/usr/lib/jvm/java-1.11-openjdk/jre \
-    PATH=$PATH:/usr/lib/jvm/java-1.11-openjdk/jre/bin:/usr/lib/jvm/java-1.11-openjdk/bin \
+ENV JAVA_VERSION=17.0.12_p8-r0 \
+    JAVA_ALPINE_VERSION=17.0.12_p8-r0 \
+    JAVA_HOME=/usr/lib/jvm/java-1.17-openjdk/jre \
+    PATH=$PATH:/usr/lib/jvm/java-1.17-openjdk/jre/bin:/usr/lib/jvm/java-1.17-openjdk/bin \
     LANG=C.UTF-8 \
 	PYTHONUNBUFFERED=1
 
@@ -16,5 +16,5 @@ RUN apk add --no-cache python3 && ln -sf python3 /usr/bin/python && \
 	pip3 install --upgrade pip setuptools && \
 	pip3 install --no-cache-dir -r /requirements.txt && \
 	rm -r /root/.cache
-RUN set -x && apk add --update ca-certificates iproute2 lsof procps openjdk11-jre="$JAVA_ALPINE_VERSION" && apk update && apk upgrade && \
+RUN set -x && apk add --update ca-certificates iproute2 lsof procps openjdk17-jre="$JAVA_ALPINE_VERSION" && apk update && apk upgrade && \
     rm -rf /tmp/* /var/cache/apk/* /requirements.txt

--- a/build/amd64/bci/Dockerfile.all_base
+++ b/build/amd64/bci/Dockerfile.all_base
@@ -2,15 +2,15 @@ FROM registry.suse.com/bci/bci-micro:15.6 AS micro
 FROM registry.suse.com/bci/bci-base:15.6 AS builder
 MAINTAINER support@neuvector.com
 
-ENV JAVA_VERSION=11.0.24_p8-r0 \
-    JAVA_HOME=/usr/lib64/jvm/jre-11-openjdk/bin \
-    PATH=$PATH:/usr/lib64/jvm/jre-11-openjdk/bin \
+ENV JAVA_VERSION=17.0.12_p8-r0 \
+    JAVA_HOME=/usr/lib64/jvm/jre-17-openjdk/bin \
+    PATH=$PATH:/usr/lib64/jvm/jre-17-openjdk/bin \
     LANG=C.UTF-8 \
     PYTHONUNBUFFERED=1
 
 COPY --from=micro / /chroot/
 RUN zypper --installroot /chroot -n --gpg-auto-import-keys in --no-recommends \
-    java-11-openjdk python312 python312-pip \
+    java-17-openjdk python312 python312-pip \
     ca-certificates iproute2 ethtool lsof procps curl jq iptables grep tar awk tcpdump sed kmod && \
     cp /etc/resolv.conf /chroot/etc/resolv.conf && \
     chroot /chroot /usr/bin/python3.12 -m pip install --upgrade pip setuptools && \

--- a/build/amd64/bci/Dockerfile.manager_base
+++ b/build/amd64/bci/Dockerfile.manager_base
@@ -2,15 +2,15 @@ FROM registry.suse.com/bci/bci-micro:15.6 AS micro
 FROM registry.suse.com/bci/bci-base:15.6 AS builder
 MAINTAINER support@neuvector.com
 
-ENV JAVA_VERSION=11.0.24_p8-r0\
-    JAVA_HOME=/usr/lib/jvm/java-1.11-openjdk/jre \
-    PATH=$PATH:/usr/lib/jvm/java-1.11-openjdk/jre/bin:/usr/lib/jvm/java-1.11-openjdk/bin \
+ENV JAVA_VERSION=17.0.12_p8-r0\
+    JAVA_HOME=/usr/lib/jvm/java-1.17-openjdk/jre \
+    PATH=$PATH:/usr/lib/jvm/java-1.17-openjdk/jre/bin:/usr/lib/jvm/java-1.17-openjdk/bin \
     LANG=C.UTF-8 \
     PYTHONUNBUFFERED=1
 
 COPY --from=micro / /chroot/
 RUN zypper --installroot /chroot -n --gpg-auto-import-keys in --no-recommends \
-    python312 python312-pip java-11-openjdk iproute2 lsof procps grep awk && \
+    python312 python312-pip java-17-openjdk iproute2 lsof procps grep awk && \
     cp /etc/resolv.conf /chroot/etc/resolv.conf && \
     chroot /chroot /usr/bin/python3.12 -m pip install --upgrade pip setuptools && \
     rm /chroot/usr/lib/python3.12/site-packages/distutils-precedence.pth && \

--- a/build/arm64/Dockerfile.all_base
+++ b/build/arm64/Dockerfile.all_base
@@ -2,15 +2,15 @@ ARG BCI_VERSION=15.6
 FROM registry.suse.com/bci/bci-micro:${BCI_VERSION} AS micro
 FROM registry.suse.com/bci/bci-base:${BCI_VERSION} AS builder
 
-ENV JAVA_VERSION=11.0.24_p8-r0 \
-    JAVA_HOME=/usr/lib/jvm/java-1.11-openjdk/jre \
-    PATH=$PATH:/usr/lib/jvm/java-1.11-openjdk/jre/bin:/usr/lib/jvm/java-1.11-openjdk/bin \
+ENV JAVA_VERSION=17.0.12_p8-r0 \
+    JAVA_HOME=/usr/lib/jvm/java-1.17-openjdk/jre \
+    PATH=$PATH:/usr/lib/jvm/java-1.17-openjdk/jre/bin:/usr/lib/jvm/java-1.17-openjdk/bin \
     LANG=C.UTF-8 \
     PYTHONUNBUFFERED=1
 
 COPY --from=micro / /chroot/
 RUN zypper --installroot /chroot -n --gpg-auto-import-keys in --no-recommends \
-    java-11-openjdk python312 python312-pip \
+    java-17-openjdk python312 python312-pip \
     ca-certificates iproute2 ethtool lsof procps curl jq iptables grep tar awk tcpdump sed kmod wget unzip \
     libnetfilter_queue-devel liburcu-devel libpcap-devel pcre2-devel libjansson-devel libmnl-devel jemalloc-devel && \
     cp /etc/resolv.conf /chroot/etc/resolv.conf && \

--- a/build/arm64/Dockerfile.build_manager
+++ b/build/arm64/Dockerfile.build_manager
@@ -5,17 +5,17 @@ FROM ubuntu:22.04
 RUN apt-get update || true
 
 # Manager
-RUN apt-get install -y build-essential autoconf libtool wget curl zip git default-jdk && \
+RUN apt-get install -y build-essential autoconf libtool wget curl zip git openjdk-17-jdk && \
     apt-get install apt-transport-https
 
 RUN curl -fL https://github.com/VirtusLab/coursier-m1/releases/latest/download/cs-aarch64-pc-linux.gz | gzip -d > cs && \
     chmod +x cs && \
     export PATH="$PATH:/root/.local/share/coursier/bin" && \
-    ./cs install scala:2.11.12 sbt:1.6.2 --install-dir /usr/local/bin
+    ./cs install scala:3.3.4 sbt:1.10.2 --install-dir /usr/local/bin
 
 RUN curl -fsSL https://deb.nodesource.com/setup_16.x | bash - && \
     apt-get install -uy nodejs && \
-    npm install -g @angular/cli@13 && \
+    npm install -g @angular/cli@14 && \
     npm install -g npm-force-resolutions
 
 # Manager unitest
@@ -23,7 +23,7 @@ RUN curl -fsSL https://deb.nodesource.com/setup_16.x | bash - && \
 #     dpkg -i google-chrome-stable_current_amd64.deb; apt-get -fy install
 
 # Fix for sbt failure, an ubuntu issue
-RUN sed -i 's/pkcs12/jks/g' /etc/java-11-openjdk/security/java.security && \
+RUN sed -i 's/pkcs12/jks/g' /etc/java-17-openjdk/security/java.security && \
     dpkg --purge --force-depends ca-certificates-java && \
     apt-get install ca-certificates-java
 

--- a/build/arm64/Dockerfile.manager_base
+++ b/build/arm64/Dockerfile.manager_base
@@ -2,15 +2,15 @@ ARG BCI_VERSION=15.6
 FROM registry.suse.com/bci/bci-micro:${BCI_VERSION} AS micro
 FROM registry.suse.com/bci/bci-base:${BCI_VERSION} AS builder
 
-ENV JAVA_VERSION=11.0.24_p8-r0 \
-    JAVA_HOME=/usr/lib/jvm/java-1.11-openjdk/jre \
-    PATH=$PATH:/usr/lib/jvm/java-1.11-openjdk/jre/bin:/usr/lib/jvm/java-1.11-openjdk/bin \
+ENV JAVA_VERSION=17.0.12_p8-r0 \
+    JAVA_HOME=/usr/lib/jvm/java-1.17-openjdk/jre \
+    PATH=$PATH:/usr/lib/jvm/java-1.17-openjdk/jre/bin:/usr/lib/jvm/java-1.17-openjdk/bin \
     LANG=C.UTF-8 \
     PYTHONUNBUFFERED=1
 
 COPY --from=micro / /chroot/
 RUN zypper --installroot /chroot -n --gpg-auto-import-keys in --no-recommends \
-    python312 python312-pip java-11-openjdk iproute2 lsof procps grep awk && \
+    python312 python312-pip java-17-openjdk iproute2 lsof procps grep awk && \
     cp /etc/resolv.conf /chroot/etc/resolv.conf && \
     chroot /chroot /usr/bin/python3.12 -m pip install --upgrade pip setuptools && \
     rm /chroot/usr/lib/python3.12/site-packages/distutils-precedence.pth && \


### PR DESCRIPTION
Version upgrades for Scala v2 to v3 migration.

angular-cli: v13 -> v14
openjdk: v11 -> v17
scala: v2.11.12 -> v3.3.4
sbt: v1.6.2 -> v1.10.2
