### PR TITLE
 NVSHAS-9537: Change builders base image to BCI - manifest portion

### DIFF
--- a/build/amd64/Dockerfile.build_fleet_v3
+++ b/build/amd64/Dockerfile.build_fleet_v3
@@ -1,0 +1,23 @@
+ARG GO_VERSION=1.22.7
+FROM registry.suse.com/bci/golang:${GO_VERSION}
+
+# Dockerfile to create container to build binaries
+
+RUN zypper ref && \
+    zypper install -y --no-recommends gcc13 gcc13-c++ make glibc-devel glibc-devel-static \
+    automake autoconf libtool libpcap-devel pcre-devel pcre2-devel curl wget zip git cmake \
+    libnfnetlink-devel libnetfilter_queue-devel libmnl-devel liburcu-devel libjansson-devel jemalloc-devel && \
+    update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-13 10 && \
+    update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-13 10
+
+# Install vectorscan
+RUN zypper addrepo https://download.opensuse.org/repositories/devel:libraries:c_c++/15.6/devel:libraries:c_c++.repo && \
+    zypper --non-interactive --gpg-auto-import-keys refresh && \
+    zypper install -y vectorscan-devel
+
+# Fleet
+ENV GOPATH=/go
+ENV PATH=$PATH:/usr/local/go/bin:$GOPATH/bin
+RUN mkdir -p $GOPATH/src/neuvector.com && mkdir -p $GOPATH/bin
+
+COPY build.sh /

--- a/build/amd64/Dockerfile.build_manager_v3
+++ b/build/amd64/Dockerfile.build_manager_v3
@@ -1,0 +1,28 @@
+ARG BCI_VERSION=15.6
+FROM registry.suse.com/bci/bci-base:${BCI_VERSION}
+
+# Dockerfile to create container to build binaries
+
+# Manager
+RUN zypper refresh && \
+    zypper install -y ca-certificates wget curl zip git awk java-17-openjdk-devel nodejs20 npm20
+
+RUN curl -fL https://github.com/coursier/launchers/raw/master/cs-x86_64-pc-linux.gz | gzip -d > cs && \
+    chmod +x cs && \
+    export PATH="$PATH:/root/.local/share/coursier/bin" && \
+    ./cs install scala:3.3.4 sbt:1.10.2 --install-dir /usr/local/bin
+
+RUN npm install -g @angular/cli@14 && \
+    npm install -g npm-force-resolutions
+
+# Manager unitest
+RUN zypper addrepo https://download.opensuse.org/repositories/M17N:fonts/15.6/M17N:fonts.repo && \
+    zypper --non-interactive --gpg-auto-import-keys refresh && \
+    zypper install -y liberation-fonts
+
+RUN wget https://dl.google.com/linux/direct/google-chrome-stable_current_x86_64.rpm && \
+    wget https://dl.google.com/linux/linux_signing_key.pub && \
+    rpm --import linux_signing_key.pub && \
+    zypper install -y google-chrome-stable_current_x86_64.rpm
+
+COPY build.sh /

--- a/build/amd64/Makefile
+++ b/build/amd64/Makefile
@@ -1,5 +1,6 @@
 STAGE_DIR = stage
 BASEOS?=bci
+BUILD_IMAGE_TAG?=
 
 stage_init:
 	rm -rf ${STAGE_DIR}; mkdir -p ${STAGE_DIR}
@@ -25,21 +26,24 @@ endif
 stage_scan_base: stage_fleet_base
 
 stage_ctrl_base: stage_fleet_base
+ifeq ($(BUILD_IMAGE_TAG),)
 	gzip -cd prebuild/binary/consul.1.11.11.gz > ${STAGE_DIR}/usr/local/bin/consul
 	chmod +x ${STAGE_DIR}/usr/local/bin/consul
 	gzip -cd prebuild/binary/opa.0.48.0.gz > ${STAGE_DIR}/usr/local/bin/opa
 	chmod +x ${STAGE_DIR}/usr/local/bin/opa
 	cp prebuild/binary/libpcre.so.3.13.1 ${STAGE_DIR}/usr/local/bin/
+endif
 
 stage_enf_base: stage_fleet_base
+ifeq ($(BUILD_IMAGE_TAG),)
 	gzip -cd prebuild/binary/consul.1.11.11.gz > ${STAGE_DIR}/usr/local/bin/consul
 	chmod +x ${STAGE_DIR}/usr/local/bin/consul
 	gzip -cd prebuild/binary/yq.4.43.1.gz > ${STAGE_DIR}/usr/local/bin/yq
 	chmod +x ${STAGE_DIR}/usr/local/bin/yq
 	tar -xvf prebuild/binary/iptables-1.8.9.tar.xz -C ${STAGE_DIR}/
-ifeq ("$(BASEOS)", "alpine")
-	cp prebuild/binary/tcpdump ${STAGE_DIR}/usr/local/bin/tcpdump
-endif
+	ifeq ("$(BASEOS)", "alpine")
+		cp prebuild/binary/tcpdump ${STAGE_DIR}/usr/local/bin/tcpdump
+	endif
 	cp prebuild/binary/libpcap.so.1 ${STAGE_DIR}/usr/lib/libpcap.so.1
 	cp prebuild/binary/libcrypto.so.1.1 ${STAGE_DIR}/usr/lib/libcrypto.so.1.1
 	cp prebuild/binary/libgcc_s.so.1 ${STAGE_DIR}/usr/local/bin/
@@ -50,6 +54,7 @@ endif
 	cp prebuild/binary/libnfnetlink.so.0.2.0 ${STAGE_DIR}/usr/local/bin/libnfnetlink.so.0.2.0
 	cp prebuild/binary/libnetfilter_queue.so.1.5.0 ${STAGE_DIR}/usr/local/bin/libnetfilter_queue.so.1.5.0
 	cp prebuild/binary/libmnl.so.0.1.0 ${STAGE_DIR}/usr/local/bin/libmnl.so.0.1.0
+endif
 
 stage_mgr_base:
 	mkdir -p ${STAGE_DIR}/etc/neuvector/certs/
@@ -67,31 +72,61 @@ ifeq ("$(BASEOS)", "alpine")
 endif
 
 updater:
+ifeq ($(BUILD_IMAGE_TAG),)
 	docker build --no-cache=true -t neuvector/updater:latest -f ${BASEOS}/Dockerfile.updater .
+else
+	docker build --no-cache=true -t neuvector/updater:latest -f ${BASEOS}_${BUILD_IMAGE_TAG}/Dockerfile.updater .
+endif
 
 scanner_base: stage_init stage_scan_base
+ifeq ($(BUILD_IMAGE_TAG),)
 	docker build --no-cache=true -t neuvector/scanner_base -f ${BASEOS}/Dockerfile.scanner_base .
+else
+	docker build --no-cache=true -t neuvector/scanner_base -f ${BASEOS}_${BUILD_IMAGE_TAG}/Dockerfile.scanner_base .
+endif
 
 controller_base: stage_init stage_ctrl_base
+ifeq ($(BUILD_IMAGE_TAG),)
 	docker build --no-cache=true -t neuvector/controller_base -f ${BASEOS}/Dockerfile.controller_base .
+else
+	docker build --no-cache=true -t neuvector/controller_base -f ${BASEOS}_${BUILD_IMAGE_TAG}/Dockerfile.controller_base .
+endif
 
 enforcer_base: stage_init stage_enf_base
+ifeq ($(BUILD_IMAGE_TAG),)
 	docker build --no-cache=true -t neuvector/enforcer_base -f ${BASEOS}/Dockerfile.enforcer_base .
+else
+	docker build --no-cache=true -t neuvector/enforcer_base -f ${BASEOS}_${BUILD_IMAGE_TAG}/Dockerfile.enforcer_base .
+endif
 
 manager_base: stage_init stage_mgr_base
+ifeq ($(BUILD_IMAGE_TAG),)
 	docker build --no-cache=true -t neuvector/manager_base -f ${BASEOS}/Dockerfile.manager_base .
+else
+	docker build --no-cache=true -t neuvector/manager_base -f ${BASEOS}_${BUILD_IMAGE_TAG}/Dockerfile.manager_base .
+endif
 
 adapter_base: stage_init stage_adpt_base
+ifeq ($(BUILD_IMAGE_TAG),)
 	docker build --no-cache=true -t neuvector/adapter_base -f ${BASEOS}/Dockerfile.adapter_base .
+else
+	docker build --no-cache=true -t neuvector/adapter_base -f ${BASEOS}_${BUILD_IMAGE_TAG}/Dockerfile.adapter_base .
+endif
 
 all_base: stage_init stage_enf_base stage_ctrl_base stage_mgr_base
+ifeq ($(BUILD_IMAGE_TAG),)
 	docker build --no-cache=true -t neuvector/all_base -f ${BASEOS}/Dockerfile.all_base .
+else
+	docker build --no-cache=true -t neuvector/all_base -f ${BASEOS}_${BUILD_IMAGE_TAG}/Dockerfile.all_base .
+endif
 
 
 build_manager:
 	docker build --no-cache=true -t neuvector/build_manager:latest -f Dockerfile.build_manager .
+	docker build --no-cache=true -t neuvector/build_manager:v3 -f Dockerfile.build_manager_v3 .
 
 build_fleet:
 	docker build --no-cache=true -t neuvector/build_fleet:latest -f Dockerfile.build_fleet .
 	docker build --no-cache=true -t neuvector/build_fleet:v1 -f Dockerfile.build_fleet_v1 .
 	docker build --no-cache=true -t neuvector/build_fleet:v2 -f Dockerfile.build_fleet_v2 .
+	docker build --no-cache=true -t neuvector/build_fleet:v3 -f Dockerfile.build_fleet_v3 .

--- a/build/amd64/bci_v3/Dockerfile.adapter_base
+++ b/build/amd64/bci_v3/Dockerfile.adapter_base
@@ -1,0 +1,17 @@
+ARG BCI_VERSION=15.6
+FROM registry.suse.com/bci/bci-micro:${BCI_VERSION} AS micro
+FROM registry.suse.com/bci/bci-base:${BCI_VERSION} AS builder
+
+COPY --from=micro / /chroot/
+RUN zypper --installroot /chroot -n --gpg-auto-import-keys in --no-recommends \
+    ca-certificates && \
+    zypper --installroot /chroot clean -a && \
+    rm -rf /chroot/var/log/
+
+FROM micro
+WORKDIR /
+COPY --from=builder /chroot/ /
+
+COPY stage /
+
+RUN cd /usr/bin/ && rm -rf basename chcon chgrp chmod chown chroot cksum dd df dircolors dirname du install install-info join locale localedef mkdir mkfifo mknod mktemp paste pathchk readlink realpath sync smidiff smidump smilink smiquery smistrip smixlate tee tiemout tload top truncate unlink watch

--- a/build/amd64/bci_v3/Dockerfile.all_base
+++ b/build/amd64/bci_v3/Dockerfile.all_base
@@ -1,0 +1,58 @@
+ARG BCI_VERSION=15.6
+FROM registry.suse.com/bci/bci-micro:${BCI_VERSION} AS micro
+FROM registry.suse.com/bci/bci-base:${BCI_VERSION} AS builder
+
+ENV JAVA_VERSION=17.0.12_p8-r0 \
+    JAVA_HOME=/usr/lib64/jvm/jre-17-openjdk/bin \
+    PATH=$PATH:/usr/lib64/jvm/jre-17-openjdk/bin \
+    LANG=C.UTF-8 \
+    PYTHONUNBUFFERED=1
+
+COPY --from=micro / /chroot/
+RUN zypper --installroot /chroot -n --gpg-auto-import-keys in --no-recommends \
+    java-17-openjdk python312 python312-pip \
+    ca-certificates iproute2 ethtool lsof procps curl jq iptables grep tar awk tcpdump sed kmod wget unzip \
+    libnetfilter_queue-devel liburcu-devel libpcap-devel pcre2-devel libjansson-devel libmnl-devel jemalloc-devel
+
+# Install yq
+RUN zypper addrepo https://download.opensuse.org/repositories/utilities/15.6/utilities.repo && \
+    zypper --installroot /chroot -n --gpg-auto-import-keys refresh && \
+    zypper --installroot /chroot install -y yq
+
+# Install vectorscan
+RUN zypper addrepo https://download.opensuse.org/repositories/devel:libraries:c_c++/15.6/devel:libraries:c_c++.repo && \
+    zypper --installroot /chroot -n --gpg-auto-import-keys refresh && \
+    zypper --installroot /chroot install -y vectorscan-devel
+
+RUN cp /etc/resolv.conf /chroot/etc/resolv.conf && \
+    chroot /chroot /usr/bin/python3.12 -m pip install --upgrade pip setuptools && \
+    rm /chroot/usr/lib/python3.12/site-packages/distutils-precedence.pth && \
+    zypper --installroot /chroot clean -a && \
+    rm -rf /chroot/var/log/
+
+FROM micro
+WORKDIR /
+COPY --from=builder /chroot/ /
+COPY --from=builder /usr/sbin/useradd /usr/sbin
+COPY stage /
+
+ARG CONSUL_VERSION=1.11.11
+ARG OPA_VERSION=v0.68.0
+
+RUN ln -s /usr/bin/python3.12 /usr/bin/python && \
+    ln -s /usr/bin/python3.12 /usr/bin/python3  && \
+    pip3 install --no-cache-dir "supervisor==4.2.5" && \
+    pip3 install --no-cache-dir -r /requirements.txt && \
+    ln -s /usr/local/bin/supervisord /usr/bin/supervisord && \
+    rm -r /root/.cache /requirements.txt
+
+RUN wget https://releases.hashicorp.com/consul/${CONSUL_VERSION}/consul_${CONSUL_VERSION}_linux_amd64.zip && \
+    unzip consul_${CONSUL_VERSION}_linux_amd64.zip -d /usr/local/bin/ && \
+    chmod +x /usr/local/bin/consul && \
+    curl -L -o /usr/local/bin/opa https://openpolicyagent.org/downloads/${OPA_VERSION}/opa_linux_amd64_static && \
+    chmod +x /usr/local/bin/opa
+
+RUN ln -s /usr/lib64/libpcap.so /usr/lib64/libpcap.so.0.8 && \
+    ln -s /usr/lib64/libpcre.so.1 /usr/lib64/libpcre.so.3
+
+RUN cd /usr/bin/ && rm -rf basename chcon chgrp chmod chown chroot cksum dd df dircolors dirname du install install-info join locale localedef mkdir mkfifo mknod mktemp paste pathchk readlink realpath sync smidiff smidump smilink smiquery smistrip smixlate tee tiemout tload top truncate unlink watch

--- a/build/amd64/bci_v3/Dockerfile.controller_base
+++ b/build/amd64/bci_v3/Dockerfile.controller_base
@@ -1,0 +1,26 @@
+ARG BCI_VERSION=15.6
+FROM registry.suse.com/bci/bci-micro:${BCI_VERSION} AS micro
+FROM registry.suse.com/bci/bci-base:${BCI_VERSION} AS builder
+
+COPY --from=micro / /chroot/
+RUN zypper --installroot /chroot -n --gpg-auto-import-keys in --no-recommends \
+    ca-certificates pcre2-devel iproute2 ethtool lsof procps curl jq iptables grep tar awk wget unzip && \
+    zypper --installroot /chroot clean -a && \
+    rm -rf /chroot/var/log/
+
+FROM micro
+WORKDIR /
+COPY --from=builder /chroot/ /
+COPY stage /
+
+ARG CONSUL_VERSION=1.11.11
+ARG OPA_VERSION=v0.68.0
+
+RUN wget https://releases.hashicorp.com/consul/${CONSUL_VERSION}/consul_${CONSUL_VERSION}_linux_amd64.zip && \
+    unzip consul_${CONSUL_VERSION}_linux_amd64.zip -d /usr/local/bin/ && \
+    chmod +x /usr/local/bin/consul && \
+    curl -L -o /usr/local/bin/opa https://openpolicyagent.org/downloads/${OPA_VERSION}/opa_linux_amd64_static && \
+    chmod +x /usr/local/bin/opa
+RUN ln -s /usr/lib64/libpcre.so.1 /usr/lib64/libpcre.so.3
+
+RUN cd /usr/bin/ && rm -rf basename chcon chgrp chmod chown chroot cksum dd df dircolors dirname du install install-info join locale localedef mkdir mkfifo mknod mktemp paste pathchk readlink realpath sync smidiff smidump smilink smiquery smistrip smixlate tee tiemout tload top truncate unlink watch

--- a/build/amd64/bci_v3/Dockerfile.enforcer_base
+++ b/build/amd64/bci_v3/Dockerfile.enforcer_base
@@ -1,0 +1,36 @@
+ARG BCI_VERSION=15.6
+FROM registry.suse.com/bci/bci-micro:${BCI_VERSION} AS micro
+FROM registry.suse.com/bci/bci-base:${BCI_VERSION} AS builder
+
+COPY --from=micro / /chroot/
+RUN zypper --installroot /chroot -n --gpg-auto-import-keys in --no-recommends \
+    ca-certificates iproute2 ethtool lsof procps curl jq iptables grep tar awk tcpdump sed kmod wget unzip \
+    libnetfilter_queue-devel liburcu-devel libpcap-devel pcre2-devel libjansson-devel libmnl-devel jemalloc-devel
+
+# Install yq
+RUN zypper addrepo https://download.opensuse.org/repositories/utilities/15.6/utilities.repo && \
+    zypper --installroot /chroot -n --gpg-auto-import-keys refresh && \
+    zypper --installroot /chroot install -y yq
+
+# Install vectorscan
+RUN zypper addrepo https://download.opensuse.org/repositories/devel:libraries:c_c++/15.6/devel:libraries:c_c++.repo && \
+    zypper --installroot /chroot -n --gpg-auto-import-keys refresh && \
+    zypper --installroot /chroot install -y vectorscan-devel
+
+RUN zypper --installroot /chroot clean -a && \
+    rm -rf /chroot/var/log/
+
+FROM micro
+WORKDIR /
+COPY --from=builder /chroot/ /
+COPY stage /
+
+ARG CONSUL_VERSION=1.11.11
+
+RUN wget https://releases.hashicorp.com/consul/${CONSUL_VERSION}/consul_${CONSUL_VERSION}_linux_amd64.zip && \
+    unzip consul_${CONSUL_VERSION}_linux_amd64.zip -d /usr/local/bin/ && \
+    chmod +x /usr/local/bin/consul
+
+RUN ln -s /usr/lib64/libpcap.so /usr/lib64/libpcap.so.0.8
+
+RUN cd /usr/bin/ && rm -rf basename chcon chgrp chmod chown chroot cksum dd df dircolors dirname du install install-info join locale localedef mkdir mkfifo mknod mktemp paste pathchk readlink realpath sync smidiff smidump smilink smiquery smistrip smixlate tee tiemout tload top truncate unlink watch

--- a/build/amd64/bci_v3/Dockerfile.manager_base
+++ b/build/amd64/bci_v3/Dockerfile.manager_base
@@ -1,0 +1,30 @@
+ARG BCI_VERSION=15.6
+FROM registry.suse.com/bci/bci-micro:${BCI_VERSION} AS micro
+FROM registry.suse.com/bci/bci-base:${BCI_VERSION} AS builder
+
+ENV JAVA_VERSION=17.0.12_p8-r0\
+    JAVA_HOME=/usr/lib/jvm/java-1.17-openjdk/jre \
+    PATH=$PATH:/usr/lib/jvm/java-1.17-openjdk/jre/bin:/usr/lib/jvm/java-1.17-openjdk/bin \
+    LANG=C.UTF-8 \
+    PYTHONUNBUFFERED=1
+
+COPY --from=micro / /chroot/
+RUN zypper --installroot /chroot -n --gpg-auto-import-keys in --no-recommends \
+    python312 python312-pip java-17-openjdk iproute2 lsof procps grep awk && \
+    cp /etc/resolv.conf /chroot/etc/resolv.conf && \
+    chroot /chroot /usr/bin/python3.12 -m pip install --upgrade pip setuptools && \
+    rm /chroot/usr/lib/python3.12/site-packages/distutils-precedence.pth && \
+    zypper --installroot /chroot clean -a && \
+    rm -rf /chroot/var/log/
+
+FROM micro
+WORKDIR /
+COPY --from=builder /chroot/ /
+COPY --from=builder /usr/sbin/useradd /usr/sbin
+COPY stage /
+
+RUN ln -s /usr/bin/python3.12 /usr/bin/python && \
+    ln -s /usr/bin/python3.12 /usr/bin/python3  && \
+    pip3 install --no-cache-dir -r /requirements.txt && \
+    rm -r /root/.cache /requirements.txt
+RUN cd /usr/bin/ && rm -rf basename chcon chgrp chmod chown chroot cksum dd df dircolors dirname du install install-info join locale localedef mkdir mkfifo mknod mktemp paste pathchk readlink realpath sync smidiff smidump smilink smiquery smistrip smixlate tee tiemout tload top truncate unlink watch

--- a/build/amd64/bci_v3/Dockerfile.scanner_base
+++ b/build/amd64/bci_v3/Dockerfile.scanner_base
@@ -1,0 +1,17 @@
+ARG BCI_VERSION=15.6
+FROM registry.suse.com/bci/bci-micro:${BCI_VERSION} AS micro
+FROM registry.suse.com/bci/bci-base:${BCI_VERSION} AS builder
+
+COPY --from=micro / /chroot/
+RUN zypper --installroot /chroot -n --gpg-auto-import-keys in --no-recommends \
+    ca-certificates procps grep && \
+    zypper --installroot /chroot clean -a && \
+    rm -rf /chroot/var/log/
+
+FROM micro
+WORKDIR /
+COPY --from=builder /chroot/ /
+
+COPY stage /
+
+RUN cd /usr/bin/ && rm -rf basename chcon chgrp chmod chown chroot cksum dd df dircolors dirname du install install-info join locale localedef mkdir mkfifo mknod mktemp paste pathchk readlink realpath sync smidiff smidump smilink smiquery smistrip smixlate tee tiemout tload top truncate unlink watch

--- a/build/amd64/bci_v3/Dockerfile.updater
+++ b/build/amd64/bci_v3/Dockerfile.updater
@@ -1,0 +1,21 @@
+ARG BCI_VERSION=15.6
+FROM registry.suse.com/bci/bci-micro:${BCI_VERSION} AS micro
+FROM registry.suse.com/bci/bci-base:${BCI_VERSION} AS builder
+
+LABEL neuvector.image="neuvector/updater" \
+      neuvector.role="updater"
+
+COPY --from=micro / /chroot/
+RUN zypper --installroot /chroot -n --gpg-auto-import-keys in --no-recommends \
+    ca-certificates curl grep && \
+    zypper --installroot /chroot clean -a && \
+    rm -rf /chroot/var/log/
+
+FROM micro
+WORKDIR /
+COPY --from=builder /chroot/ /
+COPY stage /
+
+RUN cd /usr/bin/ && rm -rf basename chcon chgrp chmod chown chroot cksum dd df dircolors dirname du install install-info join locale localedef mkdir mkfifo mknod mktemp paste pathchk readlink realpath sync smidiff smidump smilink smiquery smistrip smixlate tee tiemout tload top truncate unlink watch
+
+ENTRYPOINT ["sleep", "30"]


### PR DESCRIPTION
1. Create build_fleet_v3 and build_manager_v3 with BCI base image
2. Remove all prebuild binaries for enforcer and controller