### PR TITLE
NVSHAS-9539: Update build_fleet_v3 and base images

### DIFF
--- a/build/amd64/Dockerfile.build_fleet_v3
+++ b/build/amd64/Dockerfile.build_fleet_v3
@@ -10,8 +10,7 @@ RUN zypper ref && \
     update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-13 10 && \
     update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-13 10
 
-# Install vectorscan
-RUN zypper addrepo https://download.opensuse.org/repositories/devel:libraries:c_c++/15.6/devel:libraries:c_c++.repo && \
+RUN zypper addrepo https://download.opensuse.org/repositories/isv:SUSE:neuvector/15.6/isv:SUSE:neuvector.repo && \
     zypper --non-interactive --gpg-auto-import-keys refresh && \
     zypper install -y vectorscan-devel
 

--- a/build/amd64/bci_v3/Dockerfile.all_base
+++ b/build/amd64/bci_v3/Dockerfile.all_base
@@ -14,15 +14,9 @@ RUN zypper --installroot /chroot -n --gpg-auto-import-keys in --no-recommends \
     ca-certificates iproute2 ethtool lsof procps curl jq iptables grep tar awk tcpdump sed kmod wget unzip \
     libnetfilter_queue-devel liburcu-devel libpcap-devel pcre2-devel libjansson-devel libmnl-devel jemalloc-devel
 
-# Install yq
-RUN zypper addrepo https://download.opensuse.org/repositories/utilities/15.6/utilities.repo && \
+RUN zypper addrepo https://download.opensuse.org/repositories/isv:SUSE:neuvector/15.6/isv:SUSE:neuvector.repo && \
     zypper --installroot /chroot -n --gpg-auto-import-keys refresh && \
-    zypper --installroot /chroot install -y yq
-
-# Install vectorscan
-RUN zypper addrepo https://download.opensuse.org/repositories/devel:libraries:c_c++/15.6/devel:libraries:c_c++.repo && \
-    zypper --installroot /chroot -n --gpg-auto-import-keys refresh && \
-    zypper --installroot /chroot install -y vectorscan-devel
+    zypper --installroot /chroot install -y yq vectorscan-devel
 
 RUN cp /etc/resolv.conf /chroot/etc/resolv.conf && \
     chroot /chroot /usr/bin/python3.12 -m pip install --upgrade pip setuptools && \
@@ -36,8 +30,8 @@ COPY --from=builder /chroot/ /
 COPY --from=builder /usr/sbin/useradd /usr/sbin
 COPY stage /
 
-ARG CONSUL_VERSION=1.11.11
-ARG OPA_VERSION=v0.68.0
+ARG CONSUL_VERSION=1.20.1
+ARG OPA_VERSION=v0.70.0
 
 RUN ln -s /usr/bin/python3.12 /usr/bin/python && \
     ln -s /usr/bin/python3.12 /usr/bin/python3  && \

--- a/build/amd64/bci_v3/Dockerfile.controller_base
+++ b/build/amd64/bci_v3/Dockerfile.controller_base
@@ -13,8 +13,8 @@ WORKDIR /
 COPY --from=builder /chroot/ /
 COPY stage /
 
-ARG CONSUL_VERSION=1.11.11
-ARG OPA_VERSION=v0.68.0
+ARG CONSUL_VERSION=1.20.1
+ARG OPA_VERSION=v0.70.0
 
 RUN wget https://releases.hashicorp.com/consul/${CONSUL_VERSION}/consul_${CONSUL_VERSION}_linux_amd64.zip && \
     unzip consul_${CONSUL_VERSION}_linux_amd64.zip -d /usr/local/bin/ && \

--- a/build/amd64/bci_v3/Dockerfile.enforcer_base
+++ b/build/amd64/bci_v3/Dockerfile.enforcer_base
@@ -7,15 +7,9 @@ RUN zypper --installroot /chroot -n --gpg-auto-import-keys in --no-recommends \
     ca-certificates iproute2 ethtool lsof procps curl jq iptables grep tar awk tcpdump sed kmod wget unzip \
     libnetfilter_queue-devel liburcu-devel libpcap-devel pcre2-devel libjansson-devel libmnl-devel jemalloc-devel
 
-# Install yq
-RUN zypper addrepo https://download.opensuse.org/repositories/utilities/15.6/utilities.repo && \
+RUN zypper addrepo https://download.opensuse.org/repositories/isv:SUSE:neuvector/15.6/isv:SUSE:neuvector.repo && \
     zypper --installroot /chroot -n --gpg-auto-import-keys refresh && \
-    zypper --installroot /chroot install -y yq
-
-# Install vectorscan
-RUN zypper addrepo https://download.opensuse.org/repositories/devel:libraries:c_c++/15.6/devel:libraries:c_c++.repo && \
-    zypper --installroot /chroot -n --gpg-auto-import-keys refresh && \
-    zypper --installroot /chroot install -y vectorscan-devel
+    zypper --installroot /chroot install -y yq vectorscan-devel
 
 RUN zypper --installroot /chroot clean -a && \
     rm -rf /chroot/var/log/
@@ -25,7 +19,7 @@ WORKDIR /
 COPY --from=builder /chroot/ /
 COPY stage /
 
-ARG CONSUL_VERSION=1.11.11
+ARG CONSUL_VERSION=1.20.1
 
 RUN wget https://releases.hashicorp.com/consul/${CONSUL_VERSION}/consul_${CONSUL_VERSION}_linux_amd64.zip && \
     unzip consul_${CONSUL_VERSION}_linux_amd64.zip -d /usr/local/bin/ && \

--- a/build/arm64/Dockerfile.build_fleet_v3
+++ b/build/arm64/Dockerfile.build_fleet_v3
@@ -10,8 +10,7 @@ RUN zypper ref && \
     update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-13 10 && \
     update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-13 10
 
-# Install vectorscan
-RUN zypper addrepo https://download.opensuse.org/distribution/leap/15.5/repo/oss/ openSUSE-Leap-15.5-OSS && \
+RUN zypper addrepo https://download.opensuse.org/repositories/isv:SUSE:neuvector/15.6/isv:SUSE:neuvector.repo && \
     zypper --non-interactive --gpg-auto-import-keys refresh && \
     zypper install -y libhs5-vectorscan5 vectorscan-devel
 

--- a/build/arm64/v3/Dockerfile.all_base
+++ b/build/arm64/v3/Dockerfile.all_base
@@ -14,15 +14,9 @@ RUN zypper --installroot /chroot -n --gpg-auto-import-keys in --no-recommends \
     ca-certificates iproute2 ethtool lsof procps curl jq iptables grep tar awk tcpdump sed kmod wget unzip \
     libnetfilter_queue-devel liburcu-devel libpcap-devel pcre2-devel libjansson-devel libmnl-devel jemalloc-devel
 
-# Install yq
-RUN zypper addrepo https://download.opensuse.org/repositories/utilities/openSUSE_Factory_ARM/utilities.repo && \
+RUN zypper addrepo https://download.opensuse.org/repositories/isv:SUSE:neuvector/15.6/isv:SUSE:neuvector.repo && \
     zypper --installroot /chroot -n --gpg-auto-import-keys refresh && \
-    zypper --installroot /chroot install -y yq
-
-# Install vectorscan
-RUN zypper addrepo https://download.opensuse.org/distribution/leap/15.5/repo/oss/ openSUSE-Leap-15.5-OSS && \
-    zypper --installroot /chroot -n --gpg-auto-import-keys refresh && \
-    zypper --installroot /chroot install -y libhs5-vectorscan5 vectorscan-devel
+    zypper --installroot /chroot install -y yq vectorscan-devel
 
 RUN cp /etc/resolv.conf /chroot/etc/resolv.conf && \
     chroot /chroot /usr/bin/python3.12 -m pip install --upgrade pip setuptools && \
@@ -36,8 +30,8 @@ COPY --from=builder /chroot/ /
 COPY --from=builder /usr/sbin/useradd /usr/sbin
 COPY stage /
 
-ARG CONSUL_VERSION=1.11.11
-ARG OPA_VERSION=v0.68.0
+ARG CONSUL_VERSION=1.20.1
+ARG OPA_VERSION=v0.70.0
 
 RUN ln -s /usr/bin/python3.12 /usr/bin/python && \
     ln -s /usr/bin/python3.12 /usr/bin/python3  && \

--- a/build/arm64/v3/Dockerfile.controller_base
+++ b/build/arm64/v3/Dockerfile.controller_base
@@ -13,8 +13,8 @@ WORKDIR /
 COPY --from=builder /chroot/ /
 COPY stage /
 
-ARG CONSUL_VERSION=1.11.11
-ARG OPA_VERSION=v0.68.0
+ARG CONSUL_VERSION=1.20.1
+ARG OPA_VERSION=v0.70.0
 
 RUN wget https://releases.hashicorp.com/consul/${CONSUL_VERSION}/consul_${CONSUL_VERSION}_linux_arm64.zip && \
     unzip consul_${CONSUL_VERSION}_linux_arm64.zip -d /usr/local/bin/ && \

--- a/build/arm64/v3/Dockerfile.enforcer_base
+++ b/build/arm64/v3/Dockerfile.enforcer_base
@@ -7,15 +7,9 @@ RUN zypper --installroot /chroot -n --gpg-auto-import-keys in --no-recommends \
     ca-certificates iproute2 ethtool lsof procps curl jq iptables grep tar awk tcpdump sed kmod wget unzip \
     libnetfilter_queue-devel liburcu-devel libpcap-devel pcre2-devel libjansson-devel libmnl-devel jemalloc-devel
 
-# Install yq
-RUN zypper addrepo https://download.opensuse.org/repositories/utilities/openSUSE_Factory_ARM/utilities.repo && \
+RUN zypper addrepo https://download.opensuse.org/repositories/isv:SUSE:neuvector/15.6/isv:SUSE:neuvector.repo && \
     zypper --installroot /chroot -n --gpg-auto-import-keys refresh && \
-    zypper --installroot /chroot install -y yq
-
-# Install vectorscan
-RUN zypper addrepo https://download.opensuse.org/distribution/leap/15.5/repo/oss/ openSUSE-Leap-15.5-OSS && \
-    zypper --installroot /chroot -n --gpg-auto-import-keys refresh && \
-    zypper --installroot /chroot install -y libhs5-vectorscan5 vectorscan-devel
+    zypper --installroot /chroot install -y yq vectorscan-devel
 
 RUN zypper --installroot /chroot clean -a && \
     rm -rf /chroot/var/log/
@@ -25,7 +19,7 @@ WORKDIR /
 COPY --from=builder /chroot/ /
 COPY stage /
 
-ARG CONSUL_VERSION=1.11.11
+ARG CONSUL_VERSION=1.20.1
 
 RUN wget https://releases.hashicorp.com/consul/${CONSUL_VERSION}/consul_${CONSUL_VERSION}_linux_arm64.zip && \
     unzip consul_${CONSUL_VERSION}_linux_arm64.zip -d /usr/local/bin/ && \


### PR DESCRIPTION
1. Use isv:SUSE:neuvector repo to install yq and vectorscan
2. Upgrade consul to 1.20.1
2. Upgrade opa to v0.70.0