### PR TITLE
Update v3 build_fleet and build_manager

### DIFF
--- a/build/amd64/Dockerfile.build_fleet_v3
+++ b/build/amd64/Dockerfile.build_fleet_v3
@@ -10,6 +10,10 @@ RUN zypper ref && \
     update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-13 10 && \
     update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-13 10
 
+RUN zypper addrepo https://download.opensuse.org/repositories/devel:tools:compiler/15.6/devel:tools:compiler.repo && \
+    zypper --non-interactive --gpg-auto-import-keys refresh && \
+    zypper install -y clang17 llvm17
+
 RUN zypper addrepo https://download.opensuse.org/repositories/isv:SUSE:neuvector/15.6/isv:SUSE:neuvector.repo && \
     zypper --non-interactive --gpg-auto-import-keys refresh && \
     zypper install -y vectorscan-devel

--- a/build/amd64/Dockerfile.build_manager_v3
+++ b/build/amd64/Dockerfile.build_manager_v3
@@ -7,7 +7,8 @@ FROM registry.suse.com/bci/bci-base:${BCI_VERSION}
 RUN zypper refresh && \
     zypper install -y ca-certificates wget curl zip git awk java-17-openjdk-devel nodejs20 npm20
 
-RUN curl -fL https://github.com/coursier/launchers/raw/master/cs-x86_64-pc-linux.gz | gzip -d > cs && \
+ARG CS_VERSION=v2.1.18
+RUN curl -fL https://github.com/coursier/coursier/releases/download/${CS_VERSION}/cs-x86_64-pc-linux.gz | gzip -d > cs && \
     chmod +x cs && \
     export PATH="$PATH:/root/.local/share/coursier/bin" && \
     ./cs install scala:3.3.4 sbt:1.10.2 --install-dir /usr/local/bin

--- a/build/amd64/bci_v3/Dockerfile.all_base
+++ b/build/amd64/bci_v3/Dockerfile.all_base
@@ -43,6 +43,7 @@ RUN ln -s /usr/bin/python3.12 /usr/bin/python && \
 RUN wget https://releases.hashicorp.com/consul/${CONSUL_VERSION}/consul_${CONSUL_VERSION}_linux_amd64.zip && \
     unzip consul_${CONSUL_VERSION}_linux_amd64.zip -d /usr/local/bin/ && \
     chmod +x /usr/local/bin/consul && \
+    rm consul_${CONSUL_VERSION}_linux_amd64.zip && \
     curl -L -o /usr/local/bin/opa https://openpolicyagent.org/downloads/${OPA_VERSION}/opa_linux_amd64_static && \
     chmod +x /usr/local/bin/opa
 

--- a/build/amd64/bci_v3/Dockerfile.controller_base
+++ b/build/amd64/bci_v3/Dockerfile.controller_base
@@ -19,6 +19,7 @@ ARG OPA_VERSION=v0.70.0
 RUN wget https://releases.hashicorp.com/consul/${CONSUL_VERSION}/consul_${CONSUL_VERSION}_linux_amd64.zip && \
     unzip consul_${CONSUL_VERSION}_linux_amd64.zip -d /usr/local/bin/ && \
     chmod +x /usr/local/bin/consul && \
+    rm consul_${CONSUL_VERSION}_linux_amd64.zip && \
     curl -L -o /usr/local/bin/opa https://openpolicyagent.org/downloads/${OPA_VERSION}/opa_linux_amd64_static && \
     chmod +x /usr/local/bin/opa
 RUN ln -s /usr/lib64/libpcre.so.1 /usr/lib64/libpcre.so.3

--- a/build/amd64/bci_v3/Dockerfile.enforcer_base
+++ b/build/amd64/bci_v3/Dockerfile.enforcer_base
@@ -23,7 +23,8 @@ ARG CONSUL_VERSION=1.20.1
 
 RUN wget https://releases.hashicorp.com/consul/${CONSUL_VERSION}/consul_${CONSUL_VERSION}_linux_amd64.zip && \
     unzip consul_${CONSUL_VERSION}_linux_amd64.zip -d /usr/local/bin/ && \
-    chmod +x /usr/local/bin/consul
+    chmod +x /usr/local/bin/consul && \
+    rm consul_${CONSUL_VERSION}_linux_amd64.zip
 
 RUN ln -s /usr/lib64/libpcap.so /usr/lib64/libpcap.so.0.8
 

--- a/build/arm64/Dockerfile.build_fleet_v3
+++ b/build/arm64/Dockerfile.build_fleet_v3
@@ -10,6 +10,10 @@ RUN zypper ref && \
     update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-13 10 && \
     update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-13 10
 
+RUN zypper addrepo https://download.opensuse.org/repositories/devel:tools:compiler/15.6/devel:tools:compiler.repo && \
+    zypper --non-interactive --gpg-auto-import-keys refresh && \
+    zypper install -y clang17 llvm17
+
 RUN zypper addrepo https://download.opensuse.org/repositories/isv:SUSE:neuvector/15.6/isv:SUSE:neuvector.repo && \
     zypper --non-interactive --gpg-auto-import-keys refresh && \
     zypper install -y libhs5-vectorscan5 vectorscan-devel

--- a/build/arm64/Dockerfile.build_manager_v3
+++ b/build/arm64/Dockerfile.build_manager_v3
@@ -7,7 +7,8 @@ FROM registry.suse.com/bci/bci-base:${BCI_VERSION}
 RUN zypper refresh && \
     zypper install -y ca-certificates wget curl zip git awk java-17-openjdk-devel nodejs20 npm20
 
-RUN curl -fL https://github.com/VirtusLab/coursier-m1/releases/latest/download/cs-aarch64-pc-linux.gz | gzip -d > cs && \
+ARG CS_VERSION=v2.1.18
+RUN curl -fL https://github.com/VirtusLab/coursier-m1/releases/download/${CS_VERSION}/cs-aarch64-pc-linux.gz | gzip -d > cs && \
     chmod +x cs && \
     export PATH="$PATH:/root/.local/share/coursier/bin" && \
     ./cs install scala:3.3.4 sbt:1.10.2 --install-dir /usr/local/bin

--- a/build/arm64/v3/Dockerfile.all_base
+++ b/build/arm64/v3/Dockerfile.all_base
@@ -42,6 +42,7 @@ RUN ln -s /usr/bin/python3.12 /usr/bin/python && \
 RUN wget https://releases.hashicorp.com/consul/${CONSUL_VERSION}/consul_${CONSUL_VERSION}_linux_arm64.zip && \
     unzip consul_${CONSUL_VERSION}_linux_arm64.zip -d /usr/local/bin/ && \
     chmod +x /usr/local/bin/consul && \
+    rm consul_${CONSUL_VERSION}_linux_arm64.zip && \
     curl -L -o /usr/local/bin/opa https://openpolicyagent.org/downloads/${OPA_VERSION}/opa_linux_arm64_static && \
     chmod +x /usr/local/bin/opa
 

--- a/build/arm64/v3/Dockerfile.controller_base
+++ b/build/arm64/v3/Dockerfile.controller_base
@@ -19,6 +19,7 @@ ARG OPA_VERSION=v0.70.0
 RUN wget https://releases.hashicorp.com/consul/${CONSUL_VERSION}/consul_${CONSUL_VERSION}_linux_arm64.zip && \
     unzip consul_${CONSUL_VERSION}_linux_arm64.zip -d /usr/local/bin/ && \
     chmod +x /usr/local/bin/consul && \
+    rm consul_${CONSUL_VERSION}_linux_arm64.zip && \
     curl -L -o /usr/local/bin/opa https://openpolicyagent.org/downloads/${OPA_VERSION}/opa_linux_arm64_static && \
     chmod +x /usr/local/bin/opa
 RUN ln -s /usr/lib64/libpcre.so.1 /usr/lib64/libpcre.so.3

--- a/build/arm64/v3/Dockerfile.enforcer_base
+++ b/build/arm64/v3/Dockerfile.enforcer_base
@@ -23,7 +23,8 @@ ARG CONSUL_VERSION=1.20.1
 
 RUN wget https://releases.hashicorp.com/consul/${CONSUL_VERSION}/consul_${CONSUL_VERSION}_linux_arm64.zip && \
     unzip consul_${CONSUL_VERSION}_linux_arm64.zip -d /usr/local/bin/ && \
-    chmod +x /usr/local/bin/consul
+    chmod +x /usr/local/bin/consul && \
+    rm consul_${CONSUL_VERSION}_linux_arm64.zip
 
 RUN ln -s /usr/lib64/libpcap.so /usr/lib64/libpcap.so.0.8
 


### PR DESCRIPTION
1. Add clang17 and llvm17 into build_fleet for both amd64 and arm64
2. Use specific cs version 2.1.17 in build_manager for both amd64 and arm64