### PR TITLE
NVSHAS-9748 [Helm] NV helm update for supporting name referral for common groups in CRD

### DIFF
--- a/kubernetes/5.4.0/5.4.3_group-definition-k8s.yaml
+++ b/kubernetes/5.4.0/5.4.3_group-definition-k8s.yaml
@@ -1,0 +1,49 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: nvgroupdefinitions.neuvector.com
+spec:
+  group: neuvector.com
+  names:
+    kind: NvGroupDefinition
+    listKind: NvGroupDefinitionList
+    plural: nvgroupdefinitions
+    singular: nvgroupdefinition
+  scope: Namespaced
+  versions:
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        properties:
+          spec:
+            properties:
+              selector:
+                properties:
+                  comment:
+                    type: string
+                  criteria:
+                    items:
+                      properties:
+                        key:
+                          type: string
+                        op:
+                          type: string
+                        value:
+                          type: string
+                      required:
+                      - key
+                      - op
+                      - value
+                      type: object
+                    type: array
+                  name:
+                    type: string
+                required:
+                - name
+                type: object
+            required:
+            - selector
+            type: object
+        type: object
+    served: true
+    storage: true

--- a/kubernetes/5.4.0/crd-k8s-1.19.yaml
+++ b/kubernetes/5.4.0/crd-k8s-1.19.yaml
@@ -56,6 +56,8 @@ spec:
                           type: array
                         name:
                           type: string
+                        name_referral:
+                          type: boolean
                         original_name:
                           type: string
                       required:
@@ -127,6 +129,8 @@ spec:
                           type: array
                         name:
                           type: string
+                        name_referral:
+                          type: boolean
                         original_name:
                           type: string
                       required:
@@ -210,6 +214,8 @@ spec:
                         type: boolean
                       name:
                         type: string
+                      name_referral:
+                        type: boolean
                       original_name:
                         type: string
                     required:
@@ -323,6 +329,8 @@ spec:
                           type: array
                         name:
                           type: string
+                        name_referral:
+                          type: boolean
                         original_name:
                           type: string
                       required:
@@ -394,6 +402,8 @@ spec:
                           type: array
                         name:
                           type: string
+                        name_referral:
+                          type: boolean
                         original_name:
                           type: string
                       required:
@@ -477,6 +487,8 @@ spec:
                         type: boolean
                       name:
                         type: string
+                      name_referral:
+                        type: boolean
                       original_name:
                         type: string
                     required:


### PR DESCRIPTION
- Edited existing YAML manifest to add "name_referral" attribute on crd-k8s-1.19.yaml
- Added new file [5.4.3_group-definition-k8s.yaml] for name referral for common groups feature.