### PR TITLE
Adding fedinitcfg.yaml configuration on ConfigMap manifest for latest and 5.4.0 version

### DIFF
--- a/kubernetes/5.4.0/initcfg.yaml
+++ b/kubernetes/5.4.0/initcfg.yaml
@@ -1,5 +1,39 @@
 apiVersion: v1
 data:
+  fedinitcfg.yaml: |
+    # ============ this section is used for primary cluster ============ >>>
+    # Optional. If specified, it overwrites the cluster name specified in the system configuration in the sysinitcfg.yaml file
+    Cluster_Name: primary.cluster.local
+    # Required and must be the same on primary cluster and remote clusters
+    # It must be 36 characters long, i.e., 32 hex characters grouped as 8-4-4-4-12 and separated by four hyphens
+    Join_Token: 2be93d8f-d42a-44fc-9d33-7c1a6153066b
+    # Required: REST server/port of the neuvector-svc-controller-fed-master service
+    Primary_Rest_Info:
+      Server: 1.2.3.4
+      Port: 11443
+    # Optional. Supported value: https
+    Use_Proxy: ""
+    # Optional. Whether federal repo scan data deployment is enabled (for primary cluster only)
+    Deploy_Repo_Scan_Data: false
+    # <<< ============ this section is used for primary cluster ============
+    # ============ this section is used for remote cluster ============ >>>
+    # Optional. If specified, it overwrites the cluster name specified in the system configuration in the sysinitcfg.yaml file
+    Cluster_Name: remote.cluster.local
+    # Required and must be the same on primary cluster and remote clusters
+    # It must be 36 characters long, i.e., 32 hex characters grouped as 8-4-4-4-12 and separated by four hyphens
+    # The Join_Token specified in the remote cluster's fedinitcfg.yaml needs to be the same as the Join_Token specified in the primary cluster's fedinitcfg.yaml otherwise the auto-joining request will be declined by the primary cluster
+    Join_Token: 2be93d8f-d42a-44fc-9d33-7c1a6153066b
+    # Required: REST server/port of the neuvector-svc-controller-fed-master service
+    Primary_Rest_Info:
+      Server: 1.2.3.4
+      Port: 11443
+    # Optional, for remote cluster only. REST server/port of the neuvector-svc-controller-fed-managed service
+    Managed_Rest_Info:
+      Server: 4.3.2.1
+      Port: 10443
+    # Optional. Supported value: https
+    Use_Proxy: ""
+    # <<< ============ this section is used for remote cluster ============
   passwordprofileinitcfg.yaml: |
     # Optional. true or false or empty string(false)
     always_reload: false

--- a/kubernetes/latest/initcfg.yaml
+++ b/kubernetes/latest/initcfg.yaml
@@ -1,5 +1,39 @@
 apiVersion: v1
 data:
+  fedinitcfg.yaml: |
+    # ============ this section is used for primary cluster ============ >>>
+    # Optional. If specified, it overwrites the cluster name specified in the system configuration in the sysinitcfg.yaml file
+    Cluster_Name: primary.cluster.local
+    # Required and must be the same on primary cluster and remote clusters
+    # It must be 36 characters long, i.e., 32 hex characters grouped as 8-4-4-4-12 and separated by four hyphens
+    Join_Token: 2be93d8f-d42a-44fc-9d33-7c1a6153066b
+    # Required: REST server/port of the neuvector-svc-controller-fed-master service
+    Primary_Rest_Info:
+      Server: 1.2.3.4
+      Port: 11443
+    # Optional. Supported value: https
+    Use_Proxy: ""
+    # Optional. Whether federal repo scan data deployment is enabled (for primary cluster only)
+    Deploy_Repo_Scan_Data: false
+    # <<< ============ this section is used for primary cluster ============
+    # ============ this section is used for remote cluster ============ >>>
+    # Optional. If specified, it overwrites the cluster name specified in the system configuration in the sysinitcfg.yaml file
+    Cluster_Name: remote.cluster.local
+    # Required and must be the same on primary cluster and remote clusters
+    # It must be 36 characters long, i.e., 32 hex characters grouped as 8-4-4-4-12 and separated by four hyphens
+    # The Join_Token specified in the remote cluster's fedinitcfg.yaml needs to be the same as the Join_Token specified in the primary cluster's fedinitcfg.yaml otherwise the auto-joining request will be declined by the primary cluster
+    Join_Token: 2be93d8f-d42a-44fc-9d33-7c1a6153066b
+    # Required: REST server/port of the neuvector-svc-controller-fed-master service
+    Primary_Rest_Info:
+      Server: 1.2.3.4
+      Port: 11443
+    # Optional, for remote cluster only. REST server/port of the neuvector-svc-controller-fed-managed service
+    Managed_Rest_Info:
+      Server: 4.3.2.1
+      Port: 10443
+    # Optional. Supported value: https
+    Use_Proxy: ""
+    # <<< ============ this section is used for remote cluster ============
   passwordprofileinitcfg.yaml: |
     # Optional. true or false or empty string(false)
     always_reload: false


### PR DESCRIPTION
The fedinitcfg.yaml configuration within NeuVector configMap is not included in the example manifest given in the NeuVector documentation.
<img width="1216" height="233" alt="image" src="https://github.com/user-attachments/assets/97ee31b1-446c-4b84-aaee-01d5d402a502" />
